### PR TITLE
auto-exportを無効に設定。

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@ no-permisson: You don't have permission
 manual-import: true
 manual-export: true
 auto-import: true
-auto-export: true
+auto-export: false
 autocollect: true
 hardrecipe: false
 


### PR DESCRIPTION
auto-exportのコードベースが非常に複雑で使用しない機能の為無効化。