### PR TITLE
Fix: if Holder is Minecart or null, ClassCastException occurred.

### DIFF
--- a/src/main/java/wacky/storagesign/StorageSignCore.java
+++ b/src/main/java/wacky/storagesign/StorageSignCore.java
@@ -322,6 +322,10 @@ public class StorageSignCore extends JavaPlugin implements Listener{
 		if (event.isCancelled()) {
 			return;
 		}
+		if (event.getDestination().getHolder() instanceof Minecart ||
+				event.getDestination().getHolder() == null) {
+			return;
+		}
 
 		Sign sign = null;
 		StorageSign storageSign = null;
@@ -333,7 +337,7 @@ public class StorageSignCore extends JavaPlugin implements Listener{
 				int[] y = {1, 0, 0, 0, 0};
 				int[] z = {0, -1, 1, 0, 0};
 				BlockState blockState = (BlockState) event.getDestination().getHolder();
-				assert blockState != null;
+				// assert blockState != null;
 				Block block = blockState.getBlock().getRelative(x[i], y[i], z[i]);
 				if (i == 0 && block.getType() == Material.OAK_SIGN && isStorageSign(block)) {
 					sign = (Sign) block.getState();
@@ -366,7 +370,7 @@ public class StorageSignCore extends JavaPlugin implements Listener{
 			int[] y = {1, 0, 0, 0, 0};
 			int[] z = {0, -1, 1, 0, 0};
 			BlockState blockState = (BlockState) event.getDestination().getHolder();
-			assert blockState != null;
+			// assert blockState != null;
 			Block block = blockState.getBlock().getRelative(x[i], y[i], z[i]);
 			if (i == 0 && block.getType() == Material.OAK_SIGN && isStorageSign(block)) {
 				sign = (Sign) block.getState();


### PR DESCRIPTION
アイテムを保持しているインベントリ（ホッパーなど）が、ホッパー付きトロッコの場合や、
null の場合に `ClassCastException` が発生していた問題を修正。