### PR TITLE
Fix: if Holder is DoubleChest, ClassCastException occurred.

### DIFF
--- a/src/main/java/wacky/storagesign/StorageSignCore.java
+++ b/src/main/java/wacky/storagesign/StorageSignCore.java
@@ -323,7 +323,8 @@ public class StorageSignCore extends JavaPlugin implements Listener{
 			return;
 		}
 		if (event.getDestination().getHolder() instanceof Minecart ||
-				event.getDestination().getHolder() == null) {
+				event.getDestination().getHolder() == null ||
+				event.getDestination().getHolder() instanceof DoubleChest) {
 			return;
 		}
 


### PR DESCRIPTION
ホッパーをラージチェストに接続し、ラージチェストにアイテムが輸送されたタイミングで発生するであろうエラーを修正。